### PR TITLE
loosen minimum version requirements further

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ os:
   - osx
 julia:
   - 0.6
+addons:
+  apt:
+    packages:
+    - hdf5-tools
 notifications:
   email: false
 script:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,8 +1,8 @@
 julia 0.6 0.7-
-Clustering 0.9
-Distances 0.5
-FileIO 0.5
+Clustering 0.5
+Distances 0.2.1
+FileIO 0.3
 Gadfly 0.6
-JLD 0.8
-Measures 0.1
-StatsBase 0.18
+JLD 0.6.10
+Measures 0.0.1
+StatsBase 0.15


### PR DESCRIPTION
Pkg.test("Kpax3") passes against lower versions of almost all of the dependencies